### PR TITLE
Properly handle plain values encoding after dictionary pages.

### DIFF
--- a/lib/reader.js
+++ b/lib/reader.js
@@ -711,6 +711,7 @@ function decodePage(cursor, opts) {
 
 function decodePages(buffer, opts) {
   opts = opts || {};
+  const originalType = opts.column.originalType;
   let cursor = {
     buffer: buffer,
     offset: 0,
@@ -732,9 +733,15 @@ function decodePages(buffer, opts) {
       opts.dictionary = pageData.dictionary;
       continue;
     }
+
+    const header = pageData.pageHeader.data_page_header;
    
-    if (opts.dictionary) {
-      pageData.values = pageData.values.map(d => opts.dictionary[d]);
+    if (header.encoding == 2 /*PLAIN_DICTIONARY*/) {
+      if (opts.dictionary) {
+        pageData.values = pageData.values.map(d => opts.dictionary[d]);
+      } else {
+        throw new Error('Dictionary encoding without dictionary page.');
+      }
     }
 
     for (let i = 0; i < pageData.rlevels.length; i++) {
@@ -742,6 +749,8 @@ function decodePages(buffer, opts) {
       data.dlevels.push(pageData.dlevels[i]);
       let value = pageData.values[i];
       if (value !== undefined) {
+        if (Buffer.isBuffer(value) && originalType == 'UTF8')
+          value = String(value);
         data.values.push(value);
       }
     }


### PR DESCRIPTION
There is a bug in pages processor.
If PLAIN-encoding page occurs after we have read dictionary page (and stored dictionary), the dictionary is unconditionally used, which leads to emty (undefined) values.
This PR fixes such a case.
Also, column with originalType = 'UTF8' now consistently converts to string, not only the dictionary-encoded values.